### PR TITLE
Fix NPE in persistToDatabase

### DIFF
--- a/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/ExportApiExtractorService.kt
+++ b/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/ExportApiExtractorService.kt
@@ -79,7 +79,7 @@ class ExportApiExtractorService(
             )
             val eventTypes = extractors.flatMap { it.eventTypes }.distinct()
             val events: Map<String?, List<BuildEvent>> = exportApiClient.getEvents(build, eventTypes).toSet()
-                .map { it.data()!! }
+                .mapNotNull { it.data() }
                 .toList()
                 .groupBy(BuildEvent::eventType)
             if (!IsGradleBuild.extractFrom(events)) {


### PR DESCRIPTION
Got an NPE at https://github.com/gradle/bt-dev-prod-data-collector/blob/main/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/ExportApiExtractorService.kt#L82

```
2021-06-03T09:27:56.767887+00:00 app[web.1]: Exception in thread "DefaultDispatcher-worker-8" java.lang.NullPointerException
2021-06-03T09:27:56.767942+00:00 app[web.1]: at org.gradle.devprod.collector.enterprise.export.ExportApiExtractorService.persistToDatabase(ExportApiExtractorService.kt:82)
2021-06-03T09:27:56.767974+00:00 app[web.1]: at org.gradle.devprod.collector.enterprise.export.ExportApiExtractorService$persistToDatabase$1.invokeSuspend(ExportApiExtractorService.kt)
2021-06-03T09:27:56.768015+00:00 app[web.1]: at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
2021-06-03T09:27:56.768045+00:00 app[web.1]: at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
2021-06-03T09:27:56.768073+00:00 app[web.1]: at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
2021-06-03T09:27:56.768111+00:00 app[web.1]: at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
2021-06-03T09:27:56.768208+00:00 app[web.1]: at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
2021-06-03T09:27:56.768221+00:00 app[web.1]: at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```