### PR TITLE
Only capture long test classes in DB

### DIFF
--- a/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/ExportApiExtractorService.kt
+++ b/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/ExportApiExtractorService.kt
@@ -33,9 +33,6 @@ import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-// We only care long running test classes
-const val LONG_TEST_MS = 60 * 1000
-
 @Service
 class ExportApiExtractorService(
     private

--- a/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/extractor/extractors.kt
+++ b/ge-export/src/main/kotlin/org/gradle/devprod/collector/enterprise/export/extractor/extractors.kt
@@ -25,6 +25,9 @@ object BuildStarted : SingleEventExtractor<Instant>("BuildStarted") {
  * 3. Subtract to get the time (in ms).
  */
 object LongTestClassExtractor : Extractor<Map<String, Duration>>(listOf("TestStarted", "TestFinished")) {
+    // We only care long running test classes
+    private val longTestThreshold: Duration = Duration.ofSeconds(60)
+
     override fun extractFrom(events: Map<String?, List<BuildEvent>>): Map<String, Duration> {
         val testIdToClassName: MutableMap<Long, String> = mutableMapOf()
         val testIdToStartTime: MutableMap<Long, Instant> = mutableMapOf()
@@ -48,9 +51,9 @@ object LongTestClassExtractor : Extractor<Map<String, Duration>>(listOf("TestSta
             testIdToClassName.getValue(id) to Duration.between(testIdToStartTime.getValue(id), endTime)
         }.groupBy({ it.first }) {
             it.second
-        }.mapValues { it: Map.Entry<String, List<Duration>> ->
+        }.mapValues {
             it.value.maxOrNull()!!
-        }
+        }.filterValues { it > longTestThreshold }
     }
 }
 


### PR DESCRIPTION
so we don't use as much space in the database.

We are currently using half of the 1 million allowed rows on our current Heroku plan in the DB.