### PR TITLE
Fix paging queries for failing builds

### DIFF
--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExport.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExport.kt
@@ -27,7 +27,7 @@ class TeamcityExport(
             val existing = create.fetchAny(TEAMCITY_BUILD, TEAMCITY_BUILD.BUILD_ID.eq(build.id))
             if (existing == null) {
                 println(
-                    "Found build for branch ${build.branch} with status ${build.status}, queued at ${build.queuedDateTime}"
+                    "Found build ${build.id} for branch ${build.branch} with status ${build.status}, queued at ${build.queuedDateTime}, buildscan: ${build.buildScanUrls}"
                 )
                 create.transaction { configuration ->
                     val ctx = DSL.using(configuration)


### PR DESCRIPTION
It looks like paging didn't work or stopped working since `nextPage.nextHref` didn't contain a host. So it tried to issue the get request against localhost. It seemed to work before, so I don't know if we didn't run into paging issues or if teamcity changed the URL to be relative at some point.