### PR TITLE
Fix teamcity import

### DIFF
--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamCityBuild.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamCityBuild.kt
@@ -25,7 +25,7 @@ fun Build.toTeamCityBuild() =
         status?.name,
         revisions
             .first {
-                it.vcsRootInstance.vcsRootId.stringId == "Gradle_Branches_GradlePersonalBranches"
+                it.vcsRootInstance.vcsRootId.stringId.startsWith("GradleBuildToo")
             }
             .version,
         queuedDateTime.toOffsetDateTime(),

--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityClientService.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityClientService.kt
@@ -51,7 +51,7 @@ class TeamcityClientService(
                 .withAllBranches()
                 .since(Instant.now().minus(5, ChronoUnit.DAYS))
                 .all()
-                .map { it.toTeamCityBuild() }
+                .mapNotNull { it.toTeamCityBuild() }
         }
 
     // The rest client has no "affectProject(id:Gradle_Master_Check)" buildLocator

--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityClientService.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityClientService.kt
@@ -36,6 +36,7 @@ class TeamcityClientService(
             "Gradle_${pipeline}_Check_Stage_QuickFeedbackLinuxOnly_Trigger",
             "Gradle_${pipeline}_Check_Stage_QuickFeedback_Trigger",
             "Gradle_${pipeline}_Check_Stage_ReadyforMerge_Trigger",
+            "Gradle_${pipeline}_Check_Stage_PullRequestFeedback_Trigger",
             "Gradle_${pipeline}_Check_Stage_ReadyforNightly_Trigger",
             "Gradle_${pipeline}_Check_Stage_ReadyforRelease_Trigger"
         )


### PR DESCRIPTION
This PR fixes some problems around the Teamcity import:
- Some builds didn't have VCS roots, causing the import to fail.
- We renamed Ready for Merge to Pull Request feedback.