### PR TITLE
Expose Prometheus metrics via actuator

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-core")
+    implementation("io.micrometer:micrometer-registry-prometheus")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME:btdevprod}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD:btdevprod}
 spring.codec.max-in-memory-size=1MB
 management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.metrics.enabled=true
+management.prometheus.metrics.export.enabled=true

--- a/teamcity-export/build.gradle.kts
+++ b/teamcity-export/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation("io.micrometer:micrometer-core")
+    implementation("io.micrometer:micrometer-registry-prometheus")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/LoggingExchangeFilterFunction.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/LoggingExchangeFilterFunction.kt
@@ -1,0 +1,23 @@
+package org.gradle.devprod.collector.teamcity
+
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import reactor.core.publisher.Mono
+
+abstract class LoggingExchangeFilterFunction : ExchangeFilterFunction {
+
+    override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+        // Log request information
+        logRequest(request)
+
+        // Delegate to the next filter or the WebClient if it's the last in the chain
+        return next.exchange(request)
+            .doOnSuccess { clientResponse -> logResponse(request, clientResponse) }
+    }
+
+    open fun logRequest(request: ClientRequest) {}
+
+    open fun logResponse(request: ClientRequest, response: ClientResponse) {}
+}

--- a/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExport.kt
+++ b/teamcity-export/src/main/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExport.kt
@@ -1,5 +1,7 @@
 package org.gradle.devprod.collector.teamcity
 
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
@@ -10,6 +12,7 @@ import java.time.temporal.ChronoUnit
 class TeamcityExport(
     private val repo: Repository,
     private val teamcityClientService: TeamcityClientService,
+    private val meterRegistry: MeterRegistry,
 ) {
     private val gbtPipelines = listOf("Gradle_Master_Check", "Gradle_Release_Check")
 
@@ -25,16 +28,29 @@ class TeamcityExport(
     @Async
     @Scheduled(initialDelay = 5 * 60 * 1000, fixedDelay = 60 * 60 * 1000)
     fun loadAllGbtBuilds() {
-        println("Loading all GBT builds from Teamcity")
+        println("Loading all GBT builds from TeamCity")
 
-        teamcityClientService.loadAndStoreAllBuilds(getSinceFor("Gradle"), gbtPipelines)
+        val projectIdPrefix = "Gradle"
+        updateTeamCityExportTriggerMetric(projectIdPrefix)
+        teamcityClientService.loadAndStoreAllBuilds(getSinceFor(projectIdPrefix), gbtPipelines)
     }
 
     @Async
     @Scheduled(initialDelay = 10 * 60 * 1000, fixedDelay = 60 * 60 * 1000)
     fun loadAllGeBuilds() {
-        println("Loading all GE builds from Teamcity")
+        println("Loading all GE builds from TeamCity")
 
-        teamcityClientService.loadAndStoreAllBuilds(getSinceFor("Enterprise"), gePipelines)
+        val projectIdPrefix = "Enterprise"
+        updateTeamCityExportTriggerMetric(projectIdPrefix)
+        teamcityClientService.loadAndStoreAllBuilds(getSinceFor(projectIdPrefix), gePipelines)
+    }
+
+    private fun updateTeamCityExportTriggerMetric(projectIdPrefix: String) {
+        val instant = Instant.now().epochSecond.toDouble()
+        Gauge.builder("teamcity_export_last_scheduled_trigger_seconds", instant) { _ -> instant }
+            .description("Last instant since the TeamCity export was triggered")
+            .strongReference(true)
+            .tag("project", projectIdPrefix)
+            .register(meterRegistry)
     }
 }

--- a/teamcity-export/src/test/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExportTest.kt
+++ b/teamcity-export/src/test/kotlin/org/gradle/devprod/collector/teamcity/TeamcityExportTest.kt
@@ -1,12 +1,15 @@
 package org.gradle.devprod.collector.teamcity
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 class TeamcityExportTest {
+
+    private val meterRegistry = SimpleMeterRegistry()
 
     @Test
     @Disabled("This is a manual test that requires a live tc token")
@@ -31,8 +34,8 @@ class TeamcityExportTest {
 
         }
         val objectMapper = ObjectMapper()
-        val tcService = TeamcityClientService(teamCityApiToken = System.getenv("TC_TOKEN"), objectMapper, loggingRepo)
-        val exporter = TeamcityExport(loggingRepo, tcService)
+        val tcService = TeamcityClientService(teamCityApiToken = System.getenv("TC_TOKEN"), objectMapper, loggingRepo, meterRegistry)
+        val exporter = TeamcityExport(loggingRepo, tcService, meterRegistry)
 
         exporter.loadAllGeBuilds()
     }


### PR DESCRIPTION
Configure prometheus actuator for access through endpoint in /actuator/prometheus.

For starters, this change will introduce basic SpringBoot application metrics, plus two custom metrics specific to our application:

* `network_request_outgoing_total`: A timeseries counter for each status code/host/method combination out of TeamCityClientService requests
  * Example: `network_request_outgoing_total{client="TeamcityClientService", host="builds.gradle.org", method="GET", status_code="401"} 1.0`
* `teamcity_export_last_scheduled_trigger_seconds`: Last instant since the TeamCity export was triggered

Once exposes the metrics can be scraped by a Prometheus server and rendered in graphs.

<details><summary>You can find a full payload of exposed metrics here</summary>
<pre>
# HELP executor_pool_core_threads The core number of threads for the pool
# TYPE executor_pool_core_threads gauge
executor_pool_core_threadsnameapplicationTaskExecutor 8.0
executor_pool_core_threadsnametaskScheduler 1.0
# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
# TYPE system_load_average_1m gauge
system_load_average_1m 5.23876953125
# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
# TYPE jvm_memory_max_bytes gauge
jvm_memory_max_bytesareaheapidG1 Survivor Space -1.0
jvm_memory_max_bytesareaheapidG1 Old Gen 1.59383552E8
jvm_memory_max_bytesareanonheapidMetaspace 1.34217728E8
jvm_memory_max_bytesareanonheapidCodeCache 5.0331648E7
jvm_memory_max_bytesareaheapidG1 Eden Space -1.0
jvm_memory_max_bytesareanonheapidCompressed Class Space 1.09051904E8
# HELP logback_events_total Number of log events that were enabled by the effective log level
# TYPE logback_events_total counter
logback_events_totallevelwarn 0.0
logback_events_totalleveldebug 0.0
logback_events_totallevelerror 2.0
logback_events_totalleveltrace 0.0
logback_events_totallevelinfo 8.0
# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
# TYPE jvm_buffer_memory_used_bytes gauge
jvm_buffer_memory_used_bytesidmapped - 'non-volatile memory' 0.0
jvm_buffer_memory_used_bytesidmapped 0.0
jvm_buffer_memory_used_bytesiddirect 8413192.0
# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the (young) heap memory pool after one GC to before the next
# TYPE jvm_gc_memory_allocated_bytes_total counter
jvm_gc_memory_allocated_bytes_total 5.3477376E7
# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
# TYPE jvm_gc_memory_promoted_bytes_total counter
jvm_gc_memory_promoted_bytes_total 3029504.0
# HELP executor_queued_tasks The approximate number of tasks that are queued for execution
# TYPE executor_queued_tasks gauge
executor_queued_tasksnameapplicationTaskExecutor 0.0
executor_queued_tasksnametaskScheduler 3.0
# HELP hikaricp_connections_active Active connections
# TYPE hikaricp_connections_active gauge
hikaricp_connections_activepoolHikariPool-1 0.0
# HELP tomcat_sessions_expired_sessions_total
# TYPE tomcat_sessions_expired_sessions_total counter
tomcat_sessions_expired_sessions_total 0.0
# HELP executor_pool_size_threads The current number of threads in the pool
# TYPE executor_pool_size_threads gauge
executor_pool_size_threadsnameapplicationTaskExecutor 2.0
executor_pool_size_threadsnametaskScheduler 1.0
# HELP hikaricp_connections_max Max connections
# TYPE hikaricp_connections_max gauge
hikaricp_connections_maxpoolHikariPool-1 10.0
# HELP process_start_time_seconds Start time of the process since unix epoch.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.704702281312E9
# HELP jdbc_connections_min Minimum number of idle connections in the pool.
# TYPE jdbc_connections_min gauge
jdbc_connections_minnamedataSource 10.0
# HELP jvm_gc_max_data_size_bytes Max size of long-lived heap memory pool
# TYPE jvm_gc_max_data_size_bytes gauge
jvm_gc_max_data_size_bytes 1.59383552E8
# HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
# TYPE executor_completed_tasks_total counter
executor_completed_tasks_totalnameapplicationTaskExecutor 2.0
executor_completed_tasks_totalnametaskScheduler 2.0
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffersidmapped - 'non-volatile memory' 0.0
jvm_buffer_count_buffersidmapped 0.0
jvm_buffer_count_buffersiddirect 8.0
# HELP hikaricp_connections Total connections
# TYPE hikaricp_connections gauge
hikaricp_connectionspoolHikariPool-1 10.0
# HELP jvm_compilation_time_ms_total The approximate accumulated elapsed time spent in compilation
# TYPE jvm_compilation_time_ms_total counter
jvm_compilation_time_ms_totalcompilerHotSpot 64-Bit Tiered Compilers 802.0
# HELP hikaricp_connections_usage_seconds Connection usage time
# TYPE hikaricp_connections_usage_seconds summary
hikaricp_connections_usage_seconds_countpoolHikariPool-1 7.0
hikaricp_connections_usage_seconds_sumpoolHikariPool-1 0.032
# HELP hikaricp_connections_usage_seconds_max Connection usage time
# TYPE hikaricp_connections_usage_seconds_max gauge
hikaricp_connections_usage_seconds_maxpoolHikariPool-1 0.013
# HELP jdbc_connections_idle Number of established but idle connections.
# TYPE jdbc_connections_idle gauge
jdbc_connections_idlenamedataSource 10.0
# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
# TYPE jvm_threads_live_threads gauge
jvm_threads_live_threads 46.0
# HELP jdbc_connections_active Current number of active connections that have been allocated from the data source.
# TYPE jdbc_connections_active gauge
jdbc_connections_activenamedataSource 0.0
# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
# TYPE jvm_memory_committed_bytes gauge
jvm_memory_committed_bytesareaheapidG1 Survivor Space 3145728.0
jvm_memory_committed_bytesareaheapidG1 Old Gen 7.0254592E7
jvm_memory_committed_bytesareanonheapidMetaspace 8.192E7
jvm_memory_committed_bytesareanonheapidCodeCache 1.245184E7
jvm_memory_committed_bytesareaheapidG1 Eden Space 2097152.0
jvm_memory_committed_bytesareanonheapidCompressed Class Space 1.015808E7
# HELP system_cpu_count The number of processors available to the Java virtual machine
# TYPE system_cpu_count gauge
system_cpu_count 10.0
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
# TYPE executor_queue_remaining_tasks gauge
executor_queue_remaining_tasksnameapplicationTaskExecutor 2.147483647E9
executor_queue_remaining_tasksnametaskScheduler 2.147483647E9
# HELP hikaricp_connections_pending Pending threads
# TYPE hikaricp_connections_pending gauge
hikaricp_connections_pendingpoolHikariPool-1 0.0
# HELP process_uptime_seconds The uptime of the Java virtual machine
# TYPE process_uptime_seconds gauge
process_uptime_seconds 7.505
# HELP process_files_max_files The maximum file descriptor count
# TYPE process_files_max_files gauge
process_files_max_files 10240.0
# HELP jdbc_connections_max Maximum number of active connections that can be allocated at the same time.
# TYPE jdbc_connections_max gauge
jdbc_connections_maxnamedataSource 10.0
# HELP teamcity_export_last_scheduled_trigger_seconds Last instant since the TeamCity export was triggered
# TYPE teamcity_export_last_scheduled_trigger_seconds gauge
teamcity_export_last_scheduled_trigger_secondsprojectGradle 1.704702283E9
# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
# TYPE jvm_classes_loaded_classes gauge
jvm_classes_loaded_classes 14665.0
# HELP tomcat_sessions_created_sessions_total
# TYPE tomcat_sessions_created_sessions_total counter
tomcat_sessions_created_sessions_total 0.0
# HELP application_ready_time_seconds Time taken (ms) for the application to be ready to service requests
# TYPE application_ready_time_seconds gauge
application_ready_time_secondsmain_application_classorg.gradle.devprod.collector.DeveloperProductivityDataCollectorKt 2.028
# HELP disk_total_bytes Total space for path
# TYPE disk_total_bytes gauge
disk_total_bytespath/Users/julio/code/bt-dev-prod-data-collector/application/. 9.9466258432E11
# HELP hikaricp_connections_acquire_seconds Connection acquire time
# TYPE hikaricp_connections_acquire_seconds summary
hikaricp_connections_acquire_seconds_countpoolHikariPool-1 7.0
hikaricp_connections_acquire_seconds_sumpoolHikariPool-1 0.003
# HELP hikaricp_connections_acquire_seconds_max Connection acquire time
# TYPE hikaricp_connections_acquire_seconds_max gauge
hikaricp_connections_acquire_seconds_maxpoolHikariPool-1 0.002
# HELP tomcat_sessions_active_max_sessions
# TYPE tomcat_sessions_active_max_sessions gauge
tomcat_sessions_active_max_sessions 0.0
# HELP jvm_threads_states_threads The current number of threads
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threadsstaterunnable 17.0
jvm_threads_states_threadsstateblocked 0.0
jvm_threads_states_threadsstatewaiting 11.0
jvm_threads_states_threadsstatetimed-waiting 18.0
jvm_threads_states_threadsstatenew 0.0
jvm_threads_states_threadsstateterminated 0.0
# HELP jvm_classes_unloaded_classes_total The total number of classes unloaded since the Java virtual machine has started execution
# TYPE jvm_classes_unloaded_classes_total counter
jvm_classes_unloaded_classes_total 0.0
# HELP application_started_time_seconds Time taken (ms) to start the application
# TYPE application_started_time_seconds gauge
application_started_time_secondsmain_application_classorg.gradle.devprod.collector.DeveloperProductivityDataCollectorKt 2.011
# HELP system_cpu_usage The "recent cpu usage" of the system the application is running in
# TYPE system_cpu_usage gauge
system_cpu_usage 0.0
# HELP tomcat_sessions_rejected_sessions_total
# TYPE tomcat_sessions_rejected_sessions_total counter
tomcat_sessions_rejected_sessions_total 0.0
# HELP tomcat_sessions_alive_max_seconds
# TYPE tomcat_sessions_alive_max_seconds gauge
tomcat_sessions_alive_max_seconds 0.0
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_inforuntimeOpenJDK Runtime EnvironmentvendorBellSoftversion17.0.4+8-LTS 1.0
# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
# TYPE jvm_threads_peak_threads gauge
jvm_threads_peak_threads 47.0
# HELP jvm_gc_live_data_size_bytes Size of long-lived heap memory pool after reclamation
# TYPE jvm_gc_live_data_size_bytes gauge
jvm_gc_live_data_size_bytes 0.0
# HELP jvm_threads_daemon_threads The current number of live daemon threads
# TYPE jvm_threads_daemon_threads gauge
jvm_threads_daemon_threads 39.0
# HELP process_files_open_files The open file descriptor count
# TYPE process_files_open_files gauge
process_files_open_files 153.0
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_countactionend of minor GCcauseG1 Evacuation PausegcG1 Young Generation 5.0
jvm_gc_pause_seconds_sumactionend of minor GCcauseG1 Evacuation PausegcG1 Young Generation 0.007
# HELP jvm_gc_pause_seconds_max Time spent in GC pause
# TYPE jvm_gc_pause_seconds_max gauge
jvm_gc_pause_seconds_maxactionend of minor GCcauseG1 Evacuation PausegcG1 Young Generation 0.002
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytesareaheapidG1 Survivor Space 2502008.0
jvm_memory_used_bytesareaheapidG1 Old Gen 4.0024576E7
jvm_memory_used_bytesareanonheapidMetaspace 8.1335352E7
jvm_memory_used_bytesareanonheapidCodeCache 1.074752E7
jvm_memory_used_bytesareaheapidG1 Eden Space 0.0
jvm_memory_used_bytesareanonheapidCompressed Class Space 9905592.0
# HELP hikaricp_connections_min Min connections
# TYPE hikaricp_connections_min gauge
hikaricp_connections_minpoolHikariPool-1 10.0
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
executor_pool_max_threadsnameapplicationTaskExecutor 2.147483647E9
executor_pool_max_threadsnametaskScheduler 2.147483647E9
# HELP jvm_memory_usage_after_gc_percent The percentage of long-lived heap pool used after the last GC event, in the range [0..1]
# TYPE jvm_memory_usage_after_gc_percent gauge
jvm_memory_usage_after_gc_percentareaheappoollong-lived 0.25112111944901316
# HELP tomcat_sessions_active_current_sessions
# TYPE tomcat_sessions_active_current_sessions gauge
tomcat_sessions_active_current_sessions 0.0
# HELP disk_free_bytes Usable space for path
# TYPE disk_free_bytes gauge
disk_free_bytespath/Users/julio/code/bt-dev-prod-data-collector/application/. 7.76842047488E11
# HELP executor_active_threads The approximate number of threads that are actively executing tasks
# TYPE executor_active_threads gauge
executor_active_threadsnameapplicationTaskExecutor 0.0
executor_active_threadsnametaskScheduler 0.0
# HELP jvm_threads_started_threads_total The total number of application threads started in the JVM
# TYPE jvm_threads_started_threads_total counter
jvm_threads_started_threads_total 50.0
# HELP http_server_requests_active_seconds_max
# TYPE http_server_requests_active_seconds_max gauge
http_server_requests_active_seconds_maxexceptionnonemethodGEToutcomeSUCCESSstatus200uriUNKNOWN 0.027413833
# HELP http_server_requests_active_seconds
# TYPE http_server_requests_active_seconds summary
http_server_requests_active_seconds_active_countexceptionnonemethodGEToutcomeSUCCESSstatus200uriUNKNOWN 1.0
http_server_requests_active_seconds_duration_sumexceptionnonemethodGEToutcomeSUCCESSstatus200uriUNKNOWN 0.027396458
# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
# TYPE jvm_buffer_total_capacity_bytes gauge
jvm_buffer_total_capacity_bytesidmapped - 'non-volatile memory' 0.0
jvm_buffer_total_capacity_bytesidmapped 0.0
jvm_buffer_total_capacity_bytesiddirect 8413191.0
# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
# TYPE process_cpu_usage gauge
process_cpu_usage 0.0
# HELP network_request_outgoing_total Outgoing network request counters
# TYPE network_request_outgoing_total counter
network_request_outgoing_totalclientTeamcityClientServicehostbuilds.gradle.orgmethodGETstatus_code401 1.0
# HELP hikaricp_connections_creation_seconds_max Connection creation time
# TYPE hikaricp_connections_creation_seconds_max gauge
hikaricp_connections_creation_seconds_maxpoolHikariPool-1 0.0
# HELP hikaricp_connections_creation_seconds Connection creation time
# TYPE hikaricp_connections_creation_seconds summary
hikaricp_connections_creation_seconds_countpoolHikariPool-1 0.0
hikaricp_connections_creation_seconds_sumpoolHikariPool-1 0.0
# HELP jvm_gc_overhead_percent An approximation of the percent of CPU time used by GC activities over the last lookback period or since monitoring began, whichever is shorter, in the range [0..1]
# TYPE jvm_gc_overhead_percent gauge
jvm_gc_overhead_percent 0.0016467012275698223
# HELP hikaricp_connections_timeout_total Connection timeout total count
# TYPE hikaricp_connections_timeout_total counter
hikaricp_connections_timeout_totalpoolHikariPool-1 0.0
# HELP hikaricp_connections_idle Idle connections
# TYPE hikaricp_connections_idle gauge
hikaricp_connections_idlepoolHikariPool-1 10.0
</pre>
</details>